### PR TITLE
Fix crash on latest ual-reactjs-renderer

### DIFF
--- a/src/MeetOne.ts
+++ b/src/MeetOne.ts
@@ -165,4 +165,13 @@ export class MeetOne extends Authenticator {
     return userAgent.toLowerCase().includes('meet.one')
   }
 
+  /**
+   * Returns the amount of seconds after the authentication will be invalid for logging in on new
+   * browser sessions.  Setting this value to zero will cause users to re-attempt authentication on
+   * every new browser session.  Please note that the invalidate time will be saved client-side and
+   * should not be relied on for security.
+   */
+  public shouldInvalidateAfter(): number {
+    return 86400;
+  }
 }


### PR DESCRIPTION
The current version of ual-meetone crashes when using the latest ual-reactjs-renderer:

```
Uncaught TypeError: Cannot read property 'toLowerCase' of undefined
    at Function.boxTitle (UALBoxParts.js:251)
    at UALBoxBase.render (UALBox.js:205)
    at finishClassComponent (react-dom.development.js:17160)
    at updateClassComponent (react-dom.development.js:17110)
    at beginWork (react-dom.development.js:18620)
    at HTMLUnknownElement.callCallback (react-dom.development.js:188)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:237)
    at invokeGuardedCallback (react-dom.development.js:292)
    at beginWork$1 (react-dom.development.js:23203)
    at performUnitOfWork (react-dom.development.js:22157)
    at workLoopSync (react-dom.development.js:22130)
    at performSyncWorkOnRoot (react-dom.development.js:21756)
    at react-dom.development.js:11089
    at unstable_runWithPriority (scheduler.development.js:653)
    at runWithPriority$1 (react-dom.development.js:11039)
    at flushSyncCallbackQueueImpl (react-dom.development.js:11084)
    at flushSyncCallbackQueue (react-dom.development.js:11072)
    at scheduleUpdateOnFiber (react-dom.development.js:21199)
    at Object.enqueueSetState (react-dom.development.js:12639)
    at UALProvider.push../node_modules/ual-reactjs-renderer/node_modules/react/cjs/react.development.js.Component.setState (react.development.js:471)
    at broadcastStatus (UALProvider.js:148)
    at _callee$ (UALProvider.js:179)
    at tryCatch (runtime.js:45)
    at Generator.invoke [as _invoke] (runtime.js:274)
    at Generator.prototype.<computed> [as next] (runtime.js:97)
    at asyncGeneratorStep (UALProvider.js:13)
    at _next (UALProvider.js:13)
```

It's because the `shouldInvalidateAfter` function is missing.
This PR adds it.